### PR TITLE
added filter for collapsible code blocks

### DIFF
--- a/filters/collapse_code.py
+++ b/filters/collapse_code.py
@@ -12,7 +12,6 @@ def collapse(elem, doc):
                 """
                 <summary onclick="this.innerHTML == ' Show code ' ? this.innerHTML = ' Hide code ': this.innerHTML = ' Show code '"> Show code </summary>
                 """
-                #"<summary onclick=toggle_summary_text(this)> Show code </summary>", format="html"
             ),
             elem,
             pf.RawBlock("</details>", format="html"),

--- a/filters/collapse_code.py
+++ b/filters/collapse_code.py
@@ -1,0 +1,33 @@
+import panflute as pf
+
+def prepare(doc):
+    doc
+    pass
+
+def collapse(elem, doc):
+    if isinstance(elem, pf.CodeBlock) and "html" in doc.format:
+        content = [
+            pf.RawBlock("<details>", format="html"),
+            pf.RawBlock(
+                """
+                <summary onclick="this.innerHTML == ' Show code ' ? this.innerHTML = ' Hide code ': this.innerHTML = ' Show code '"> Show code </summary>
+                """
+                #"<summary onclick=toggle_summary_text(this)> Show code </summary>", format="html"
+            ),
+            elem,
+            pf.RawBlock("</details>", format="html"),
+        ]
+        div = pf.Div(*content, classes=["collapsible_code"])
+        return div
+
+def finalize(doc):
+    pass
+
+def main(doc=None):
+    return pf.run_filter(collapse,
+                         prepare=prepare,
+                         finalize=finalize,
+                         doc=doc)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added filter "collapse_code.py" for HTML documents. 
- Will search document and add `<div>` with HTML5 `<details>` and `<summary>` tags around all CodeBlocks. 
- The `<summary>` block contains an `onclick` javascript event that will toggle `innerHTML` between "Show code" and "Hide code".

before:
```python
print("test")
```

after (text toggle via javascript not working here):
<div class="collapsible_code">
<details>
<summary onclick="this.innerHTML == ' Show code ' ? this.innerHTML = ' Hide code ': this.innerHTML = ' Show code '"> Show code </summary>

```python
print("test")
```

</details>
</div>